### PR TITLE
Enable Github summary report

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -55,5 +55,5 @@ jobs:
           poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
           echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
           poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY || true
-          poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
+          # poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
           poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -54,6 +54,6 @@ jobs:
           poetry run nox -s project:report -- -- --format markdown >> $GITHUB_STEP_SUMMARY
           poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
           echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
-          poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY
+          poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY || true
           poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
           poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -55,4 +55,5 @@ jobs:
           poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
           echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
           poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY
+          poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
           poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -33,7 +33,7 @@ jobs:
           # Errors during copying are ignored because they are checked in the next step
           cp .coverage ../ || true
           cp lint-python3.9/.lint.txt ../ || true
-          cp lint-python3.9/.lint.txt ../ || true
+          cp lint-python3.9/.lint.json ../ || true
           cp security-python3.9/.security.json ../ || true
 
       - name: Validate Artifacts
@@ -51,9 +51,9 @@ jobs:
       - name: Generate GitHub Summary
         run: |
           echo -e "# Summary\n" >> $GITHUB_STEP_SUMMARY
-          poetry run nox -s project:report -- -- --format markdown >> $GITHUB_STEP_SUMMARY
-          poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
+          poetry run -- nox -s project:report -- -- --format markdown >> $GITHUB_STEP_SUMMARY
+          poetry run -- nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
           echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
           poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY || true
-          # poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
-          poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY
+          poetry run -- tbx lint pretty-print >> $GITHUB_STEP_SUMMARY
+          poetry run -- tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -55,5 +55,4 @@ jobs:
           poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
           echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
           poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY
-          poetry run tbx security pretty-print >> $GITHUB_STEP_SUMMARY
           poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -48,12 +48,12 @@ jobs:
           name: metrics.json
           path: metrics.json
 
-      # - name: Generate GitHub Summary
-      #   run: |
-      #     echo -e "# Summary\n" >> $GITHUB_STEP_SUMMARY
-      #     poetry run nox -s project:report -- -- --format markdown >> $GITHUB_STEP_SUMMARY
-      #     poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
-      #     echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
-      #     poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY
-      #     poetry run tbx security pretty-print >> $GITHUB_STEP_SUMMARY
-      #     poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY
+      - name: Generate GitHub Summary
+        run: |
+          echo -e "# Summary\n" >> $GITHUB_STEP_SUMMARY
+          poetry run nox -s project:report -- -- --format markdown >> $GITHUB_STEP_SUMMARY
+          poetry run nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\n# Coverage\n" >> $GITHUB_STEP_SUMMARY
+          poetry run coverage report -- --format markdown >> $GITHUB_STEP_SUMMARY
+          poetry run tbx security pretty-print >> $GITHUB_STEP_SUMMARY
+          poetry run tbx security pretty-print .security.json >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,9 @@ doc/api
 itde/
 
 # Emacs
-TAGS
+/TAGS
+
+# PTB
+/.lint.json
+/.lint.txt
+/.security.json

--- a/debug_python_toolbox.py
+++ b/debug_python_toolbox.py
@@ -1,17 +1,22 @@
-import nox
-
-# imports from PTB
-from typing import Optional, Union
 import datetime
-from pathlib import Path
-from exasol.toolbox.metrics import Report
 import json
-from tempfile import TemporaryDirectory
-from nox import Session
 
 # new imports
 import subprocess
 import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# imports from PTB
+from typing import (
+    Optional,
+    Union,
+)
+
+import nox
+from exasol.toolbox.metrics import Report
+from nox import Session
+
 
 def total_coverage(file: Union[str, Path]) -> float:
     with TemporaryDirectory() as tmpdir:

--- a/debug_python_toolbox.py
+++ b/debug_python_toolbox.py
@@ -14,7 +14,13 @@ from typing import (
 )
 
 import nox
-from exasol.toolbox.metrics import Report
+from exasol.toolbox.metrics import (
+    Report,
+    maintainability,
+    reliability,
+    security,
+    technical_debt,
+)
 from nox import Session
 
 
@@ -53,7 +59,6 @@ def create_report(
     pylint_report: Union[str, Path] = ".lint.txt",
     bandit_report: Union[str, Path] = ".security.json",
 ) -> Report:
-    return total_coverage(coverage_report)
     return Report(
         commit=commit,
         date=date if date is not None else datetime.datetime.now(),

--- a/debug_python_toolbox.py
+++ b/debug_python_toolbox.py
@@ -31,11 +31,11 @@ def total_coverage(file: Union[str, Path]) -> float:
         stdout = p.stdout.strip()
         if (p.returncode == 1) and (stdout == "No data to report."):
             print(
-                f'The following command'
-                f' returned non-zero exit status {p.returncode}:\n'
+                f"The following command"
+                f" returned non-zero exit status {p.returncode}:\n"
                 f'  {" ".join(p.args)}\n'
-                f'{stdout}\n'
-                'Returning total coverage 100 %.',
+                f"{stdout}\n"
+                "Returning total coverage 100 %.",
                 file=sys.stderr,
             )
             return 100.0

--- a/debug_python_toolbox.py
+++ b/debug_python_toolbox.py
@@ -1,0 +1,68 @@
+import nox
+
+# imports from PTB
+from typing import Optional, Union
+import datetime
+from pathlib import Path
+from exasol.toolbox.metrics import Report
+import json
+from tempfile import TemporaryDirectory
+from nox import Session
+
+# new imports
+import subprocess
+import sys
+
+def total_coverage(file: Union[str, Path]) -> float:
+    with TemporaryDirectory() as tmpdir:
+        tmp_dir = Path(tmpdir)
+        report = tmp_dir / "coverage.json"
+        p = subprocess.run(
+            ["coverage", "json", f"--data-file={file}", "-o", f"{report}"],
+            capture_output=True,
+            check=False,
+            encoding="utf-8",
+        )
+        stdout = p.stdout.strip()
+        if (p.returncode == 1) and (stdout == "No data to report."):
+            print(
+                f'The following command'
+                f' returned non-zero exit status {p.returncode}:\n'
+                f'  {" ".join(p.args)}\n'
+                f'{stdout}\n'
+                'Returning total coverage 100 %.',
+                file=sys.stderr,
+            )
+            return 100.0
+        with open(report, encoding="utf-8") as r:
+            data = json.load(r)
+            total: float = data["totals"]["percent_covered"]
+
+        return total
+
+
+def create_report(
+    commit: str,
+    date: Optional[datetime.datetime] = None,
+    coverage_report: Union[str, Path] = ".coverage",
+    pylint_report: Union[str, Path] = ".lint.txt",
+    bandit_report: Union[str, Path] = ".security.json",
+) -> Report:
+    return total_coverage(coverage_report)
+    return Report(
+        commit=commit,
+        date=date if date is not None else datetime.datetime.now(),
+        coverage=total_coverage(coverage_report),
+        maintainability=maintainability(pylint_report),
+        reliability=reliability(),
+        security=security(bandit_report),
+        technical_debt=technical_debt(),
+    )
+
+
+@nox.session(name="project:report", python=False)
+def report(session: Session) -> None:
+    sha1 = str(
+        session.run("git", "rev-parse", "HEAD", external=True, silent=True)
+    ).strip()
+    project_report = create_report(commit=sha1)

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,9 +1,7 @@
 # Unreleased
 
-## Features
 
-* #1: Added initial Project Setup
-
+## Summary
 
 Findings in `report.yml`, columns: 
 * DEVDOC: whether the resp. finding affects the repository developer-documentation, 
@@ -15,3 +13,13 @@ Findings in `report.yml`, columns:
 | Step "Generate GitHub Summary", `poetry run -- coverage report --format markdown` | must ignore coverage error due to no data | Y | Y | Y |
 | Step "Copy Artifacts into Root Folder" | copies 2x `.lint.txt` but must copy `.lint.json`, too | Y | - | Y |
 | Step "Generate GitHub Summary" | contains 2x security, but must be 1x lint and 1x security | Y | - | - |
+
+
+## Features
+
+* #1: Added initial Project Setup
+
+## Bug Fixes
+
+* Fixed findings described above
+

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -4,3 +4,14 @@
 
 * #1: Added initial Project Setup
 
+
+Findings in `report.yml`, columns: 
+* DEVDOC: whether the resp. finding affects the repository developer-documentation, 
+* PTB: whether the finding affects the folder `.github/workflows/` in the PTB
+* PTB Template:  whether the finding affects the folder `exasol/toolbox/templates/github/workflows/` in the PTB 
+
+| Location | Finding | DEVDOC | PTB | PTB Template |
+|----------|---------|--------|-----|---|
+| Step "Generate GitHub Summary", `poetry run -- coverage report --format markdown` | must ignore coverage error due to no data | Y | Y | Y |
+| Step "Copy Artifacts into Root Folder" | copies 2x `.lint.txt` but must copy `.lint.json`, too | Y | - | Y |
+| Step "Generate GitHub Summary" | contains 2x security, but must be 1x lint and 1x security | Y | - | - |

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,4 +7,3 @@ from exasol.toolbox.nox.tasks import *
 nox.options.sessions = ["project:fix"]
 
 from debug_python_toolbox import report
-

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,3 +5,6 @@ from exasol.toolbox.nox.tasks import *
 
 # default actions to be run if nothing is explicitly specified with the -s option
 nox.options.sessions = ["project:fix"]
+
+from debug_python_toolbox import report
+


### PR DESCRIPTION
Findings in `report.yml`, columns: 
* DEVDOC: whether the resp. finding affects the repository developer-documentation, 
* PTB: whether the finding affects the folder `.github/workflows/` in the PTB
* PTB Template:  whether the finding affects the folder `exasol/toolbox/templates/github/workflows/` in the PTB 

| Location | Finding | DEVDOC | PTB | PTB Template |
|----------|---------|--------|-----|---|
| Step "Generate GitHub Summary", `poetry run -- coverage report --format markdown` | must ignore coverage error due to no data | Y | Y | Y |
| Step "Copy Artifacts into Root Folder" | copies 2x `.lint.txt` but must copy `.lint.json`, too | Y | - | Y |
| Step "Generate GitHub Summary" | contains 2x security, but must be 1x lint and 1x security | Y | - | - |


